### PR TITLE
1.0.4 - Reduce memory usage via array stores & additional binance example

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orderbooks",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Minimal state stores and handlers for caching multiple exchange:symbol orderbook states in memory",
   "main": "src/index.js",
   "scripts": {

--- a/samples/binance.js
+++ b/samples/binance.js
@@ -1,7 +1,7 @@
 const Binance = require('node-binance-api');
 const binance = new Binance().options({});
 
-const { OrderBooksStore, OrderBookLevel } = require('orderbooks');
+const { OrderBooksStore, OrderBookLevel } = require('../src');
 
 const OrderBooks = new OrderBooksStore({ traceLog: true, checkTimestamps: false, maxDepth: 50 });
 
@@ -65,7 +65,8 @@ const handleOrderbookUpdate = depth => {
 
 // utility method to decide if a delta level is an upsert or deletion
 const assignLevel = (level, updateArray, deleteArray) => {
-  if (level.qty) {
+  const qtyIndex = 3;
+  if (level[qtyIndex]) {
     updateArray.push(level);
   } else {
     deleteArray.push(level);

--- a/samples/binance2.js
+++ b/samples/binance2.js
@@ -1,5 +1,5 @@
 const api = require('binance');
-const { OrderBooksStore, OrderBookLevel } = require('orderbooks');
+const { OrderBooksStore, OrderBookLevel } = require('../src');
 
 const binanceWS = new api.BinanceWS(true);
 const binanceRest = new api.BinanceRest({

--- a/samples/binance2.js
+++ b/samples/binance2.js
@@ -1,0 +1,41 @@
+const api = require('binance');
+const { OrderBooksStore, OrderBookLevel } = require('orderbooks');
+
+const binanceWS = new api.BinanceWS(true);
+const binanceRest = new api.BinanceRest({
+  disableBeautification: false,
+  handleDrift: true
+});
+
+const OrderBooks = new OrderBooksStore({ traceLog: true, checkTimestamps: false, maxDepth: 40 });
+
+// connect to a websocket and relay orderbook events to handlers
+const symbol = 'BTCUSDT';
+binanceWS.onDepthLevelUpdate(symbol, 20, depth => {
+  console.clear();
+  return handleOrderbookSnapshot(symbol, depth);
+});
+
+// get initial book snapshot
+binanceRest.depth(symbol).then(results => handleOrderbookSnapshot(symbol, results));
+
+// This binance module only provides full snapshots
+const handleOrderbookSnapshot = (symbol, snapshot) => {
+  // combine bids and asks
+  const { bids, asks } = snapshot;
+
+  const bidsArray = bids.map(([price, amount]) => {
+    return OrderBookLevel(symbol, +price, 'Buy', +amount);
+  });
+
+  const asksArray = asks.map(([price, amount]) => {
+    return OrderBookLevel(symbol, +price, 'Sell', +amount);
+  });
+
+  // store inititial snapshot
+  OrderBooks.handleSnapshot(
+    symbol,
+    [...bidsArray, ...asksArray],
+    new Date().getTime()
+  ).print();
+}

--- a/samples/package.json
+++ b/samples/package.json
@@ -12,6 +12,7 @@
   "license": "MIT",
   "dependencies": {
     "@pxtrn/bybit-api": "^1.1.5",
+    "binance": "^1.3.5",
     "node-binance-api": "^0.11.11",
     "orderbooks": "^1.0.3"
   }

--- a/src/OrderBook.js
+++ b/src/OrderBook.js
@@ -1,3 +1,11 @@
+const EnumLevelProperty = Object.freeze({
+  symbol: 0,
+  price: 1,
+  side: 2,
+  qty: 3,
+  extraState: 4
+});
+
 /**
  * Storage helper to store/track/manipulate the current state of an orderbook, for a specific symbol
  * @class SymbolOrderBook
@@ -88,7 +96,7 @@ class SymbolOrderBook {
    * @returns {number} index of level in book, if found, else -1
    */
   findIndexForSlice(level) {
-    return this.book.findIndex(e => e.price == level.price);
+    return this.book.findIndex(e => e[EnumLevelProperty.price] == level[EnumLevelProperty.price]);
   }
 
   /**
@@ -109,7 +117,7 @@ class SymbolOrderBook {
    */
   sort() {
     // sorts with lowest price last, highest price first
-    this.book.sort((a, b) => b.price - a.price);
+    this.book.sort((a, b) => b[EnumLevelProperty.price] - a[EnumLevelProperty.price]);
     return this;
   }
 
@@ -124,7 +132,7 @@ class SymbolOrderBook {
     }
 
     const count = book.reduce((acc, level) => {
-      if (level.side == 'Sell') {
+      if (level[EnumLevelProperty.side] == 'Sell') {
         acc.sells++;
         return acc;
       }
@@ -179,8 +187,7 @@ class SymbolOrderBook {
    * @public dump orderbook state to console
    */
   print() {
-    const symbol = this.symbol;
-    console.log(`---------- ${symbol} ask:bid ${this.getBestAsk()}:${this.getBestBid()} & spread: ${this.getSpreadPercent().toFixed(2)}%`);
+    console.log(`---------- ${this.symbol} ask:bid ${this.getBestAsk()}:${this.getBestBid()} & spread: ${this.getSpreadPercent().toFixed(5)}%`);
     console.table(this.book);
     return this;
   }
@@ -199,10 +206,10 @@ class SymbolOrderBook {
    * @returns {number} lowest seller price
    */
   getBestAsk(n = 0) {
-    const sellSide = this.book.filter(e => e.side == 'Sell');
+    const sellSide = this.book.filter(e => e[EnumLevelProperty.side] == 'Sell');
     const index = sellSide.length - 1 - n;
     const bottomSell = sellSide[Math.abs(index)];
-    return bottomSell && bottomSell.price;
+    return bottomSell && bottomSell[EnumLevelProperty.price];
   }
 
   /**
@@ -211,9 +218,9 @@ class SymbolOrderBook {
    * @returns {number} highest buyer price
    */
   getBestBid(n = 0) {
-    const buySide = this.book.filter(e => e.side == 'Buy');
+    const buySide = this.book.filter(e => e[EnumLevelProperty.side] == 'Buy');
     const topBuy = buySide[Math.abs(n)];
-    return topBuy && topBuy.price;
+    return topBuy && topBuy[EnumLevelProperty.price];
   }
 
   /**

--- a/src/OrderBookLevel.js
+++ b/src/OrderBookLevel.js
@@ -6,9 +6,9 @@
  * @param {number} qty asset at this level
  */
 const OrderBookLevel = (symbol, price, side, qty, ...extraState) => {
-  const level = { symbol, price, side, qty };
+  const level = [symbol, price, side, qty];
   if (extraState.length) {
-    level.extraState = extraState;
+    level.push(extraState);
   }
   return level;
 }


### PR DESCRIPTION
- Each level is now stored in-memory in array format: `[symbol, price, side, qty, extraState]`.
- Add example for other binance module.