### PR TITLE
Fixed wrong type in handleSnapshot

### DIFF
--- a/src/OrderBooksStore.ts
+++ b/src/OrderBooksStore.ts
@@ -45,7 +45,7 @@ export class OrderBooksStore {
    */
   public handleSnapshot(
     symbol: string,
-    data: OrderBookLevelState,
+    data: OrderBookLevelState[],
     timestamp: number = Date.now(),
   ): OrderBook {
     if (this.traceLog) {


### PR DESCRIPTION
Fixed wrong type for parameter data in handleSnapshot OrderBooksStore API it should be an OrderBookLevelState[] instead of OrderBookLevelState, just like function handleDelta's parameters

## Summary
<!-- Add a brief description of the pr: -->

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
